### PR TITLE
Tweak error messages

### DIFF
--- a/lib/Hash/LRU.pm6
+++ b/lib/Hash/LRU.pm6
@@ -97,14 +97,21 @@ module Hash::LRU:ver<0.0.2>:auth<cpan:ELIZABETH> {
         die "Can only apply 'is LRU' on a Hash, not a {v.var.WHAT}"
           unless v.var.WHAT ~~ Hash;
         my $name = v.var.^name;
-        with %LRU<elements> {
-            trait_mod:<does>(v, v.var.keyof =:= Str(Any)
-              ?? limit-given-hash[$_]
-              !! limit-given-object-hash[$_]
-            );
+
+        if %LRU<elements>:exists {
+            with %LRU<elements> {
+                trait_mod:<does>(v, v.var.keyof =:= Str(Any)
+                  ?? limit-given-hash[$_]
+                  !! limit-given-object-hash[$_]
+                );
+            }
+            else {
+                die "Cannot use an undefined value for 'elements' in 'is LRU'. "
+                    ~ 'Did you try to set it at runtime?';
+            }
         }
-        elsif %LRU.keys.sort -> @huh {
-            die "Don't know what to do with '@keys' in 'is LRU'";
+        elsif %LRU.keys.sort -> @keys {
+            die "Don't know what to do with '{ @keys }' in 'is LRU'";
         }
         v.var.WHAT.^set_name("$name\(LRU)");
     }


### PR DESCRIPTION
A use of Hash::LRU like

    my $size = 20;
    my %hash is LRU( elements => $size );

resulted in the following error message being printed:

    Don't know what to do with '@keys' in 'is LRU'

which does not give a very clear indication of what the source of the problem is, which is that the value of $size is not available at compile time. This change makes the
error message print this instead:

    Cannot use an undefined value for 'elements' in 'is LRU'. Did you try to set it at runtime?

It also fixes the error message printed when an unknown attribute is passed instead of 'elements':

    Don't know what to do with 'foo' in 'is LRU'